### PR TITLE
docs: clarify fallback backend security caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,17 @@ These backends use your operating system's built-in credential management and pr
 - Access restricted to your current user session
 - Supports multiple keyrings and collections
 
+### ⚠️ Fallback Command Resolution Caveat (PATH)
+
+CLI-based fallback backends invoke external commands by executable name (`security`, `secret-tool`, `powershell`/`pwsh`).
+If the process `PATH` is compromised or untrusted, a malicious executable with the same name could be run.
+
+**Mitigations:**
+
+- Prefer native backends in production
+- Run in trusted environments with controlled `PATH`
+- Avoid untrusted shell/profile scripts that modify `PATH`
+
 ### ⚠️ File Backend - LIMITED SECURITY
 
 **WARNING**: The file backend provides encryption but has significant limitations compared to OS backends.


### PR DESCRIPTION
## Preliminary - Human written message 

Hi @magarcia! First, thank you for this project! I'm the author of @bjesuiter/codex-switcher (aka cdx cli). 
I implemented the cli for macos first, but now i want to fan out to windows and linux and got to the point where i searched if somebody already did that. 

Since I want to use it and it is security relevant, i wanted to review the implementation with my trusty codex clanker :) 
Hope you don't mind, I've added this note so you see that I'm a real human who read part of your code and does not simply throw vibe-slop at maintainers. ^^

## Audit Changes (by openai-codex-5.3-high)

### What
- Add a Windows fallback warning similar to macOS: secret material can be briefly visible in process command lines when using the PowerShell fallback backend.
- Clarify Windows fallback persistence behavior and trade-offs:
  - document that fallback currently defaults to `enterprise` (roaming credentials),
  - explain when to choose `local` for machine-local scope.
- Add a PATH-resolution caveat for CLI fallback backends (`security`, `secret-tool`, `powershell`/`pwsh`) and list practical mitigations.

### Why
- Make fallback threat-model caveats explicit and consistent across platforms.
- Align docs with current Windows fallback behavior to avoid operator confusion.
- Help enterprise users (including employees switching PCs often) choose the right persistence setting intentionally.

### Scope
- Documentation only (`README.md`)
- No runtime behavior changes
